### PR TITLE
Allow configuring domain for waffle cookies in settings

### DIFF
--- a/waffle/defaults.py
+++ b/waffle/defaults.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 
 COOKIE = 'dwf_%s'
+COOKIE_DOMAIN = None
 TEST_COOKIE = 'dwft_%s'
 SECURE = True
 MAX_AGE = 2592000  # 1 month in seconds

--- a/waffle/middleware.py
+++ b/waffle/middleware.py
@@ -9,6 +9,7 @@ class WaffleMiddleware(object):
     def process_response(self, request, response):
         secure = get_setting('SECURE')
         max_age = get_setting('MAX_AGE')
+        domain = get_setting('COOKIE_DOMAIN')
 
         if hasattr(request, 'waffles'):
             for k in request.waffles:
@@ -20,7 +21,7 @@ class WaffleMiddleware(object):
                 else:
                     age = max_age
                 response.set_cookie(name, value=active, max_age=age,
-                                    secure=secure)
+                                    domain=domain, secure=secure)
         if hasattr(request, 'waffle_tests'):
             for k in request.waffle_tests:
                 name = smart_str(get_setting('TEST_COOKIE') % k)


### PR DESCRIPTION
This allows configuring in Django app settings WAFFLE_COOKIE_DOMAIN, by default set to None, so no domain is set.

No automated tests, but this has proven to work on my local. Moving this forward but perhaps it would be nice to properly implement and contribute to django-waffle. I did quick search and didn't see any PR or issue requesting that, though in our case we need it